### PR TITLE
Directly convert tweet id to timestamp

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
       });
 
       // Use latest tweet id to get the timestamp
-      var date = new Date(Math.floor(String(Math.floor(latestTweetId / 4194304))) + 1288834974657);
+      var date = new Date(Math.floor(latestTweetId / 4194304) + 1288834974657);
 
       // Subtract from now and convert to days (from milliseconds)
       var daysAgo = (new Date - date) / 1000 / 60 / 60 / 24;

--- a/index.html
+++ b/index.html
@@ -51,29 +51,22 @@
         twttr.widgets.createTweet(archiveTweetId, tweetDiv, {});
       });
 
+      // Use latest tweet id to get the timestamp
+      var date = new Date(Math.floor(String(Math.floor(latestTweetId / 4194304))) + 1288834974657);
+
+      // Subtract from now and convert to days (from milliseconds)
+      var daysAgo = (new Date - date) / 1000 / 60 / 60 / 24;
+      var daysAgoInt = Math.floor(daysAgo);
+      var counterDiv = document.getElementById('counter');
+      counterDiv.textContent = daysAgoInt;
+
       // Use twitter's widget js api to make a tweet widget out of the latest tweet id
       var latest = twttr.widgets.createTweet(latestTweetId, document.getElementById('latestTweet'), {});
 
       // TODO: really it would be better to get a timestamp by pulling the right bits out of the tweet id
       //       rather than digging through the iframe
       latest.then(function(tweetIFrame) {
-
-        // Dig through the iframe dom twitter gives us to find the tweet's timestamp
-        var embeddedElement = tweetIFrame.contentWindow.document.getElementsByClassName('EmbeddedTweet')[0];
-        var timeStampString = embeddedElement.getAttribute('data-dt-explicit-timestamp');
-
-        // The timestamp looks like "12:50 PM - Mar 21, 2006", so switch that to
-        // something Date can parse
-        var parts = timeStampString.split('-');
-        var formattedTimeStampString = parts[1].trim() + ' ' + parts[0].trim();
-        var date = new Date(formattedTimeStampString);
-
-        // Subtract from now and convert to days (from milliseconds)
-        var daysAgo = (new Date - date) / 1000 / 60 / 60 / 24;
-        var daysAgoInt = Math.floor(daysAgo);
-        var counterDiv = document.getElementById('counter');
-        counterDiv.textContent = daysAgoInt;
-
+        
         // dynamically replace favicon
         var iconFilename = (daysAgoInt < 100) ? (daysAgoInt.toString()) : "unlikely";
         iconFilename = "./images/" + iconFilename + ".ico";


### PR DESCRIPTION
This will work even if twitter element is blocked by tracking
protection.